### PR TITLE
Add word-wrap to prevent long page titles.

### DIFF
--- a/.dev/sass/mixins/_global.scss
+++ b/.dev/sass/mixins/_global.scss
@@ -381,6 +381,7 @@ $cursor-text-value: text !default;
 			line-height: $base-line-height; // Set to $base-line-height to take on browser default of 150%
 			cursor: $cursor-default-value;
 			-webkit-font-smoothing: antialiased;
+			word-wrap: break-word;
 		}
 
 	a:hover { cursor: $cursor-pointer-value; }

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -45,7 +45,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }

--- a/editor-style.css
+++ b/editor-style.css
@@ -45,7 +45,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -64,7 +64,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -159,7 +160,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -1246,7 +1248,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }

--- a/style.css
+++ b/style.css
@@ -64,7 +64,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -159,7 +160,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }
@@ -1246,7 +1248,8 @@ body {
   font-style: normal;
   line-height: 150%;
   cursor: default;
-  -webkit-font-smoothing: antialiased; }
+  -webkit-font-smoothing: antialiased;
+  word-wrap: break-word; }
 
 a:hover {
   cursor: pointer; }


### PR DESCRIPTION
Discovered during theme unit testing checklist.

Before:
![Long Title Example](https://cldup.com/23RMooQ6Ja.png)

After:
![Long Title After](https://cldup.com/wfPrbuVA2s.png)
