### PR TITLE
Clear .page-content:after, to avoid overflows

### DIFF
--- a/.dev/sass/mixins/_functions.scss
+++ b/.dev/sass/mixins/_functions.scss
@@ -104,11 +104,11 @@ $modules: () !default;
 
 // Clearfix
 @mixin clearfix() {
-		content: "";
-		display: table;
+	content: "";
+	display: table;
 }
 
 // Center after (not all clearfix need this also)
 @mixin clearfix-after() {
-		clear: both;
+	clear: both;
 }

--- a/.dev/sass/partials/_clearings.scss
+++ b/.dev/sass/partials/_clearings.scss
@@ -3,6 +3,8 @@
 .comment-content,
 .site-header,
 .site-content,
-.site-footer {
+.site-footer,
+.page-content {
 	@include clearfix;
+	@include clearfix-after;
 }

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -64,7 +64,7 @@
 			&:hover{
 				background-color: $secondary-color;
 			}
-			
+
 		}
 
 	}
@@ -297,7 +297,6 @@ body.no-max-width .main-navigation {
 		@extend .columns;
 		margin-bottom: 1em;
 		margin-bottom: 1rem;
-		padding: 0;
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2205,8 +2205,7 @@ body.no-max-width .main-navigation {
  */
 .navigation .nav-links {
   margin-bottom: 1em;
-  margin-bottom: 1rem;
-  padding: 0; }
+  margin-bottom: 1rem; }
 
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2283,27 +2283,37 @@ body.no-max-width .main-navigation {
   display: block;
   margin: 0 auto; }
 
-.clear:before, .clear:after,
-.entry-content:before,
-.entry-content:after,
-.comment-content:before,
-.comment-content:after,
-.site-header:before,
-.site-header:after,
-.site-content:before,
-.site-content:after,
-.site-footer:before,
-.site-footer:after {
-  content: " ";
-  display: table; }
-
-.clear:after,
-.entry-content:after,
-.comment-content:after,
-.site-header:after,
-.site-content:after,
-.site-footer:after {
+.clear,
+.entry-content,
+.comment-content,
+.site-header,
+.site-content,
+.site-footer,
+.page-content {
   clear: both; }
+  .clear:before, .clear:after,
+  .entry-content:before,
+  .entry-content:after,
+  .comment-content:before,
+  .comment-content:after,
+  .site-header:before,
+  .site-header:after,
+  .site-content:before,
+  .site-content:after,
+  .site-footer:before,
+  .site-footer:after,
+  .page-content:before,
+  .page-content:after {
+    content: " ";
+    display: table; }
+  .clear:after,
+  .entry-content:after,
+  .comment-content:after,
+  .site-header:after,
+  .site-content:after,
+  .site-footer:after,
+  .page-content:after {
+    clear: both; }
 
 .widget {
   margin: 0 0 1.5em;

--- a/style.css
+++ b/style.css
@@ -2205,8 +2205,7 @@ body.no-max-width .main-navigation {
  */
 .navigation .nav-links {
   margin-bottom: 1em;
-  margin-bottom: 1rem;
-  padding: 0; }
+  margin-bottom: 1rem; }
 
 .comment-navigation .nav-previous,
 .paging-navigation .nav-previous,

--- a/style.css
+++ b/style.css
@@ -2283,27 +2283,37 @@ body.no-max-width .main-navigation {
   display: block;
   margin: 0 auto; }
 
-.clear:before, .clear:after,
-.entry-content:before,
-.entry-content:after,
-.comment-content:before,
-.comment-content:after,
-.site-header:before,
-.site-header:after,
-.site-content:before,
-.site-content:after,
-.site-footer:before,
-.site-footer:after {
-  content: " ";
-  display: table; }
-
-.clear:after,
-.entry-content:after,
-.comment-content:after,
-.site-header:after,
-.site-content:after,
-.site-footer:after {
+.clear,
+.entry-content,
+.comment-content,
+.site-header,
+.site-content,
+.site-footer,
+.page-content {
   clear: both; }
+  .clear:before, .clear:after,
+  .entry-content:before,
+  .entry-content:after,
+  .comment-content:before,
+  .comment-content:after,
+  .site-header:before,
+  .site-header:after,
+  .site-content:before,
+  .site-content:after,
+  .site-footer:before,
+  .site-footer:after,
+  .page-content:before,
+  .page-content:after {
+    content: " ";
+    display: table; }
+  .clear:after,
+  .entry-content:after,
+  .comment-content:after,
+  .site-header:after,
+  .site-content:after,
+  .site-footer:after,
+  .page-content:after {
+    clear: both; }
 
 .widget {
   margin: 0 0 1.5em;


### PR DESCRIPTION
Before Fix:
![Content Page Overflow](https://cldup.com/tMsVSl-2vJ.png)

After
![After Clearfix Implemented](https://cldup.com/8VVSS-prD1.png)

Also fixes the post/page nav links visible outside of the body wrapper.

Before:
![Before Fix](https://cldup.com/rs5jOimyv9.png)

After:
![After Fix](https://cldup.com/CnGiq3-INL.png)
