### PR TITLE
Tweak site styles. Prevent menu button overlay

### DIFF
--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -2,7 +2,7 @@ $entry-title-bg: rgba(0, 0, 0, 0.6) !default;
 
 .site-header .site-title-wrapper {
 	float: left;
-	margin-left: 15px;
+	margin: 0 0 30px 15px;
 
 	@media #{$large-down} {
 		position: absolute;

--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -10,13 +10,13 @@ $entry-title-bg: rgba(0, 0, 0, 0.6) !default;
 	}
 
 	@media #{$medium-only} {
-		max-width: 80%;
+		max-width: 90%;
 		z-index: 8;
 		position: relative;
 	}
 
 	@media #{$small-only} {
-		max-width: 80%;
+		max-width: 75%;
 		z-index: 8;
 		position: relative;
 	}

--- a/.dev/sass/partials/_header.scss
+++ b/.dev/sass/partials/_header.scss
@@ -9,6 +9,18 @@ $entry-title-bg: rgba(0, 0, 0, 0.6) !default;
 		z-index: 999999;
 	}
 
+	@media #{$medium-only} {
+		max-width: 80%;
+		z-index: 8;
+		position: relative;
+	}
+
+	@media #{$small-only} {
+		max-width: 80%;
+		z-index: 8;
+		position: relative;
+	}
+
 }
 
 .site-title {

--- a/.dev/sass/partials/_hero.scss
+++ b/.dev/sass/partials/_hero.scss
@@ -4,6 +4,10 @@
 
 body.home .hero {
 	padding: 150px 0;
+
+	@media #{$small-only} {
+		padding: 0;
+	}
 }
 
 .hero {

--- a/functions.php
+++ b/functions.php
@@ -19,8 +19,10 @@ function lyrical_move_elements() {
 
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation' );
 	remove_action( 'primer_after_header', 'primer_add_page_title' );
+	remove_action( 'primer_header', 'primer_add_site_title' );
 
-	add_action( 'primer_header', 'primer_add_primary_navigation', 5 );
+	add_action( 'primer_header', 'primer_add_site_title', 8 );
+	add_action( 'primer_header', 'primer_add_primary_navigation', 9 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3119,12 +3119,12 @@ body.page-template-page-builder-no-header #primary {
       z-index: 999999; } }
   @media only screen and (min-width: 40.063em) and (max-width: 61em) {
     .site-header .site-title-wrapper {
-      max-width: 80%;
+      max-width: 90%;
       z-index: 8;
       position: relative; } }
   @media only screen and (max-width: 40em) {
     .site-header .site-title-wrapper {
-      max-width: 80%;
+      max-width: 75%;
       z-index: 8;
       position: relative; } }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3117,6 +3117,16 @@ body.page-template-page-builder-no-header #primary {
     .site-header .site-title-wrapper {
       position: absolute;
       z-index: 999999; } }
+  @media only screen and (min-width: 40.063em) and (max-width: 61em) {
+    .site-header .site-title-wrapper {
+      max-width: 80%;
+      z-index: 8;
+      position: relative; } }
+  @media only screen and (max-width: 40em) {
+    .site-header .site-title-wrapper {
+      max-width: 80%;
+      z-index: 8;
+      position: relative; } }
 
 .site-title {
   font-family: "Playfair Display", "Raleway", "Open Sans", "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3112,7 +3112,7 @@ body.page-template-page-builder-no-header #primary {
 
 .site-header .site-title-wrapper {
   float: right;
-  margin-right: 15px; }
+  margin: 0 15px 30px 0; }
   @media only screen and (max-width: 61.063em) {
     .site-header .site-title-wrapper {
       position: absolute;
@@ -3261,6 +3261,9 @@ body.page-template-page-builder-no-header #primary {
 
 body.home .hero {
   padding: 150px 0; }
+  @media only screen and (max-width: 40em) {
+    body.home .hero {
+      padding: 0; } }
 
 .hero {
   padding-top: 55px; }

--- a/style.css
+++ b/style.css
@@ -3119,12 +3119,12 @@ body.page-template-page-builder-no-header #primary {
       z-index: 999999; } }
   @media only screen and (min-width: 40.063em) and (max-width: 61em) {
     .site-header .site-title-wrapper {
-      max-width: 80%;
+      max-width: 90%;
       z-index: 8;
       position: relative; } }
   @media only screen and (max-width: 40em) {
     .site-header .site-title-wrapper {
-      max-width: 80%;
+      max-width: 75%;
       z-index: 8;
       position: relative; } }
 

--- a/style.css
+++ b/style.css
@@ -3112,7 +3112,7 @@ body.page-template-page-builder-no-header #primary {
 
 .site-header .site-title-wrapper {
   float: left;
-  margin-left: 15px; }
+  margin: 0 0 30px 15px; }
   @media only screen and (max-width: 61.063em) {
     .site-header .site-title-wrapper {
       position: absolute;
@@ -3261,6 +3261,9 @@ body.page-template-page-builder-no-header #primary {
 
 body.home .hero {
   padding: 150px 0; }
+  @media only screen and (max-width: 40em) {
+    body.home .hero {
+      padding: 0; } }
 
 .hero {
   padding-top: 55px; }

--- a/style.css
+++ b/style.css
@@ -3117,6 +3117,16 @@ body.page-template-page-builder-no-header #primary {
     .site-header .site-title-wrapper {
       position: absolute;
       z-index: 999999; } }
+  @media only screen and (min-width: 40.063em) and (max-width: 61em) {
+    .site-header .site-title-wrapper {
+      max-width: 80%;
+      z-index: 8;
+      position: relative; } }
+  @media only screen and (max-width: 40em) {
+    .site-header .site-title-wrapper {
+      max-width: 80%;
+      z-index: 8;
+      position: relative; } }
 
 .site-title {
   font-family: "Playfair Display", "Raleway", "Open Sans", "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
This patch prevents long site titles from overlaying on the menu button. 

Additionally, users can now use multi-line site titles and descriptions. Previously it would overlay on the .hero element. Now longer titles simply push down the .hero element, instead of overlaying on it.

Examples (with patch applied)

Tablet:
![Tablet Layout](https://cldup.com/JLLPmrDAZA.png)

Mobile:
![Mobile Layout](https://cldup.com/YR2a8D7Bcs.png)
