### PR TITLE
Update Primer hook priorities 

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -9,6 +9,7 @@
 		float: left;
 		padding: 0;
 		margin-bottom: 0;
+		background: $secondary-color;
 
 		.quantity {
 			display: block;
@@ -35,9 +36,10 @@
 		}
 
 		.total {
-			margin: 0 0 10px 0;
-			padding-top: 10px;
+			margin: 0;
+			padding: 10px 0;
 			text-align: center;
+			color: #333;
 
 			strong {
 				text-indent: 0;
@@ -47,6 +49,7 @@
 
 		p.buttons {
 			padding: .5em;
+			padding-top: 0;
 			margin: 0;
 
 			a {
@@ -100,7 +103,7 @@
 				}
 
 				a:nth-child(2) {
-					padding: .5em 0em;
+					padding: .5em 0 0 0;
 					margin: 0;
 					width: 100%;
 					text-indent: 1.75rem;
@@ -150,21 +153,23 @@ body.woocommerce-cart {
 	}
 }
 
-.woocommerce #content table.cart img,
-.woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
-.woocommerce-page table.cart img {
-	width: 100%;
-	max-width: 90px;
-	display: block;
-	margin: 0 auto;
-}
+.woocommerce,
+.woocommerce-page {
 
-.woocommerce #content table.cart td.actions .input-text,
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-	padding: 7px;
+	table.cart {
+
+		img {
+			width: 100%;
+			max-width: 100px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 10px !important;
+		}
+
+	}
+
 }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
@@ -173,10 +178,15 @@ body.woocommerce-cart {
 	text-align: center;
 }
 
-@media #{$medium-down} {
+@media #{$large-down} {
 
-	.primer-wc-cart-menu .primer-wc-cart-sub-menu {
-		width: 100%;
+	.primer-wc-cart-menu {
+
+		.primer-wc-cart-sub-menu,
+		.widget_shopping_cart {
+			width: 100%;
+		}
+
 	}
 
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -17,7 +17,7 @@
 		}
 
 		ul.product_list_widget {
-			position: relative !important;
+			position: relative;
 			left: 0;
 			max-height: 250px;
 			overflow-y: auto;
@@ -94,7 +94,7 @@
 						line-height: .8;
 
 						&:hover {
-							background: red !important;
+							background: red;
 						}
 					}
 				}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -148,7 +148,9 @@ body.single-product {
 .woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
 	width: 100%;
-	margin-bottom: 0;
+	max-width: 90px;
+	display: block;
+	margin: 0 auto;
 }
 
 .woocommerce #content table.cart td.actions .input-text,

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -143,6 +143,13 @@ body.single-product {
 	}
 }
 
+body.woocommerce-cart {
+
+	.primer-wc-cart-sub-menu {
+		display: none;
+	}
+}
+
 .woocommerce #content table.cart img,
 .woocommerce table.cart img,
 .woocommerce-page #content table.cart img,

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -33,6 +33,8 @@ ul.site-header-cart.menu {
 	ul.product_list_widget {
 		position: relative !important;
 		left: 0;
+		max-height: 250px;
+		overflow-y: auto;
 	}
 
 	p.buttons,
@@ -149,6 +151,32 @@ ul.site-header-cart.menu {
 		&:hover {
 			background: red !important;
 		}
+	}
+
+}
+
+body.post-type-archive,
+body.single-product {
+
+	/* On Sale Badge */
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
+}
+
+body.single-product {
+
+	span.onsale {
+		padding: 3px 18px;
+		top: 0;
+		left: 0;
 	}
 
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -160,6 +160,11 @@ body.single-product {
 	padding: 7px;
 }
 
+.woocommerce ul.products li.product a.add_to_cart_button {
+	width: 100%;
+	font-size: 16px;
+	text-align: center;
+}
 
 @media #{$medium-down} {
 

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,117 +1,169 @@
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-    float: right;
-}
-
-.main-navigation .menu-item-object-cart a {
-    padding-left: 0;
-    float: right;
-    cursor: pointer;
-}
-
-.main-navigation .menu-item-object-cart a i {
-    font-size: 20px;
-}
-
 .main-navigation .menu-item-object-cart:hover a {
-    background: transparent;
-}
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-    float: left;
-    margin-right: 1rem;
-    font-weight: bold;
-}
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-    float: left;
-    font-weight: 200;
+	background: transparent;
 }
 
 ul.site-header-cart.menu {
-    width: 100%;
-    max-width: 275px;
-    padding: 0;
-    list-style: none;
-    float: right;
-    display: none;
-    position: relative;
-    z-index: 10001;
-		background: $menu-background-color;
+	width: 100%;
+	max-width: 275px;
+	padding: 0;
+	list-style: none;
+	float: right;
+	display: none;
+	position: relative;
+	z-index: 10001;
 }
 
-ul.site-header-cart.menu li {
-    border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-    -webkit-box-shadow: 0 0 10px 0 grey;
-    box-shadow: 0 0 10px 0 grey;
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+	display: none;
 }
 
-ul.site-header-cart.menu ul.product_list_widget li {
-    border: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
+.widget_shopping_cart {
+
+	float: left;
+	padding: 0 1rem;
+	margin-bottom: .5em;
+
+	.quantity {
+		display: block;
+		float: left;
+		font-style: italic;
+	}
+
+	ul.product_list_widget {
+		position: relative !important;
+		left: 0;
+	}
+
+	p.buttons,
+	.total,
+	.product_list_widget {
+		float: left;
+		width: 100%;
+	}
+
+	.total strong {
+		text-index: 0;
+	}
+
+	p.buttons {
+		padding: .5em;
+		margin: 0;
+	}
+
 }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-    margin-bottom: 0;
-    padding: 10px 0 2px 0;
+.woocommerce-cart-menu-item .sub-menu {
+	background: transparent;
 }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-    padding: 0 .5em;
-    max-height: 220px;
-    overflow-y: auto;
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+	padding: 0;
+	margin: 0;
+	width: 100%;
+	padding-bottom: 5px;
+	border-bottom: none;
+	padding: .5em 1em;
+	text-indent: 0;
+	opacity: 1;
+	transition: opacity .25s ease-out;
+	-moz-transition: opacity .25s ease-out;
+	-webkit-transition: opacity .25s ease-out;
+	-o-transition: opacity .25s ease-out;
+
+	img {
+		width: 100%;
+		max-width: 55px;
+	}
+
+	a {
+		border-bottom: none;
+	}
+
+	a:nth-child(2) {
+		padding: .5em 0em;
+		margin: 0;
+		width: 100%;
+		text-indent: 1.75rem;
+	}
+
+	&:hover {
+		opacity: .85;
+	}
 }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-    width: 55px;
-    -webkit-border-radius: 5px;
-    border-radius: 5px;
+.woocommerce-cart-menu-item {
+
+	.product_list_widget {
+		border: none;
+		box-shadow: none;
+		display: inline-block;
+		left: 0 !important;
+		background: inherit;
+	}
+
+	.widget_shopping_cart {
+
+		padding: 0;
+		margin-bottom: 0;
+
+		.total {
+			margin: 0 0 10px 0;
+			padding-top: 10px;
+			text-align: center;
+		}
+
+		.total strong {
+			text-indent: 0;
+		}
+
+		p.buttons a {
+			text-align: center;
+			width: 100%;
+			text-indent: 0;
+			background-color: $color-background-button;
+
+			&:first-child {
+				margin-bottom: 5px;
+			}
+
+		}
+
+	}
+
+	.cart-preview-count {
+		margin-left: 8px;
+	}
+
+	.cart_list li a.remove {
+		position: relative;
+		float: left;
+		padding: 0;
+		margin-top: 18px;
+		text-indent: 0;
+		margin-right: 5px;
+		z-index: 1001;
+		line-height: .8;
+		text-indent: 0 !important;
+
+		&:hover {
+			background: red !important;
+		}
+	}
+
 }
 
-ul.site-header-cart.menu .widget_shopping_cart .total {
-    padding: 10px;
-    margin: .5em 0;
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+	border-bottom: none;
+	text-indent: 15px;
+	margin-left: 10px;
+	color: inherit;
 }
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-    padding: 0 .5em;
-    margin: 0;
-}
+@media #{$medium-up} {
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-    display: block;
-    width: 100%;
-    text-align: center;
-}
+	li#woocommerce-cart-menu-item .sub-menu {
+		margin-left: -6em;
+	}
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
-	padding-top: 2px;
-}
-
-.site-header-cart-container {
-    width: 100%;
-    display: block;
-    max-width: 1100px;
-    margin: 0 auto;
-    position: absolute;
-    right: 0;
-    left: 0;
-		margin-top: 8px;
-}
-
-.site-header-cart-container .buttons a {
-    margin-bottom: 5px;
-}
-
-body.woocommerce .quantity input.input-text.qty {
-	padding: .45em;
-}
-
-@media only screen and (max-width: 61.063em) {
-    .menu-item-object-cart {
-        display: none;
-    }
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -92,7 +92,7 @@
 					&.remove {
 						float: left;
 						padding: 0;
-						margin: 18px 0 0 15px;
+						margin: 20px 0 0 15px;
 						z-index: 1001;
 						line-height: .8;
 

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -158,12 +158,21 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
 	text-indent: 15px;
 	margin-left: 10px;
 	color: inherit;
+	background: inherit;
 }
 
-@media #{$medium-up} {
+@media #{$large-up} {
 
 	li#woocommerce-cart-menu-item .sub-menu {
 		margin-left: -6em;
+	}
+
+}
+
+@media #{$large-down} {
+
+	li #woocommerce-cart-menu-item .widget_shopping_cart {
+		width: 100%;
 	}
 
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,0 +1,117 @@
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+    float: right;
+}
+
+.main-navigation .menu-item-object-cart a {
+    padding-left: 0;
+    float: right;
+    cursor: pointer;
+}
+
+.main-navigation .menu-item-object-cart a i {
+    font-size: 20px;
+}
+
+.main-navigation .menu-item-object-cart:hover a {
+    background: transparent;
+}
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+    float: left;
+    margin-right: 1rem;
+    font-weight: bold;
+}
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+    float: left;
+    font-weight: 200;
+}
+
+ul.site-header-cart.menu {
+    width: 100%;
+    max-width: 275px;
+    padding: 0;
+    list-style: none;
+    float: right;
+    display: none;
+    position: relative;
+    z-index: 10001;
+		background: $menu-background-color;
+}
+
+ul.site-header-cart.menu li {
+    border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+    -webkit-box-shadow: 0 0 10px 0 grey;
+    box-shadow: 0 0 10px 0 grey;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart {
+    margin-bottom: 0;
+    padding: 10px 0 2px 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+    padding: 0 .5em;
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+    width: 55px;
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+    padding: 10px;
+    margin: .5em 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+    padding: 0 .5em;
+    margin: 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+    display: block;
+    width: 100%;
+    text-align: center;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
+	padding-top: 2px;
+}
+
+.site-header-cart-container {
+    width: 100%;
+    display: block;
+    max-width: 1100px;
+    margin: 0 auto;
+    position: absolute;
+    right: 0;
+    left: 0;
+		margin-top: 8px;
+}
+
+.site-header-cart-container .buttons a {
+    margin-bottom: 5px;
+}
+
+body.woocommerce .quantity input.input-text.qty {
+	padding: .45em;
+}
+
+@media only screen and (max-width: 61.063em) {
+    .menu-item-object-cart {
+        display: none;
+    }
+}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,158 +1,121 @@
-.main-navigation .menu-item-object-cart:hover a {
-	background: transparent;
-}
+.primer-wc-cart-menu {
 
-ul.site-header-cart.menu {
-	width: 100%;
-	max-width: 275px;
-	padding: 0;
-	list-style: none;
-	float: right;
-	display: none;
-	position: relative;
-	z-index: 10001;
-}
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-	display: none;
-}
-
-.widget_shopping_cart {
-
-	float: left;
-	padding: 0 1rem;
-	margin-bottom: .5em;
-
-	.quantity {
-		display: block;
-		float: left;
-		font-style: italic;
-	}
-
-	ul.product_list_widget {
-		position: relative !important;
-		left: 0;
-		max-height: 250px;
-		overflow-y: auto;
-	}
-
-	p.buttons,
-	.total,
-	.product_list_widget {
-		float: left;
-		width: 100%;
-	}
-
-	.total strong {
-		text-index: 0;
-	}
-
-	p.buttons {
-		padding: .5em;
-		margin: 0;
-	}
-
-}
-
-.woocommerce-cart-menu-item .sub-menu {
-	background: transparent;
-}
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-	padding: 0;
-	margin: 0;
-	width: 100%;
-	padding-bottom: 5px;
-	border-bottom: none;
-	padding: .5em 1em;
-	text-indent: 0;
-	opacity: 1;
-	transition: opacity .25s ease-out;
-	-moz-transition: opacity .25s ease-out;
-	-webkit-transition: opacity .25s ease-out;
-	-o-transition: opacity .25s ease-out;
-
-	img {
-		width: 100%;
-		max-width: 55px;
-	}
-
-	a {
-		border-bottom: none;
-	}
-
-	a:nth-child(2) {
-		padding: .5em 0em;
-		margin: 0;
-		width: 100%;
-		text-indent: 1.75rem;
-	}
-
-	&:hover {
-		opacity: .85;
-	}
-}
-
-.woocommerce-cart-menu-item {
-
-	.product_list_widget {
-		border: none;
-		box-shadow: none;
-		display: inline-block;
-		left: 0 !important;
-		background: inherit;
+	.primer-wc-cart-sub-menu {
+		width: 250px;
 	}
 
 	.widget_shopping_cart {
 
+		float: left;
 		padding: 0;
 		margin-bottom: 0;
+
+		.quantity {
+			display: block;
+			float: left;
+			font-style: italic;
+		}
+
+		ul.product_list_widget {
+			position: relative !important;
+			left: 0;
+			max-height: 250px;
+			overflow-y: auto;
+			border: none;
+			box-shadow: none;
+			display: inline-block;
+			background: inherit;
+		}
+
+		p.buttons,
+		.total,
+		.product_list_widget {
+			float: left;
+			width: 100%;
+		}
 
 		.total {
 			margin: 0 0 10px 0;
 			padding-top: 10px;
 			text-align: center;
-		}
 
-		.total strong {
-			text-indent: 0;
-		}
-
-		p.buttons a {
-			text-align: center;
-			width: 100%;
-			text-indent: 0;
-			background-color: $color-background-button;
-
-			&:first-child {
-				margin-bottom: 5px;
+			strong {
+				text-indent: 0;
 			}
 
 		}
 
+		p.buttons {
+			padding: .5em;
+			margin: 0;
+
+			a {
+				text-align: center;
+				width: 100%;
+				text-indent: 0;
+				background-color: $color-background-button;
+
+				&:first-child {
+					margin-bottom: 5px;
+				}
+			}
+		}
+
+		.cart_list {
+
+			background: transparent;
+			box-shadow: none;
+
+			li.mini_cart_item {
+				padding: 0;
+				margin: 0;
+				width: 100%;
+				padding-bottom: 5px;
+				border-bottom: none;
+				padding: .5em 1em;
+				text-indent: 0;
+				opacity: 1;
+				transition: opacity .25s ease-out;
+
+				img {
+					width: 100%;
+					max-width: 55px;
+				}
+
+				a {
+					border-bottom: none;
+					background: inherit;
+
+					&.remove {
+						float: left;
+						padding: 0;
+						margin: 18px 0 0 15px;
+						z-index: 1001;
+						line-height: .8;
+
+						&:hover {
+							background: red !important;
+						}
+					}
+				}
+
+				a:nth-child(2) {
+					padding: .5em 0em;
+					margin: 0;
+					width: 100%;
+					text-indent: 1.75rem;
+				}
+
+				&:hover {
+					opacity: .85;
+				}
+			}
+		}
 	}
 
 	.cart-preview-count {
 		margin-left: 8px;
 	}
-
-	.cart_list li a.remove {
-		position: relative;
-		float: left;
-		padding: 0;
-		margin-top: 18px;
-		text-indent: 0;
-		margin-right: 5px;
-		z-index: 1001;
-		line-height: .8;
-		text-indent: 0 !important;
-
-		&:hover {
-			background: red !important;
-		}
-	}
-
 }
 
 body.post-type-archive,
@@ -178,28 +141,27 @@ body.single-product {
 		top: 0;
 		left: 0;
 	}
-
 }
 
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-	border-bottom: none;
-	text-indent: 15px;
-	margin-left: 10px;
-	color: inherit;
-	background: inherit;
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+	width: 100%;
+	margin-bottom: 0;
 }
 
-@media #{$large-up} {
-
-	li#woocommerce-cart-menu-item .sub-menu {
-		margin-left: -6em;
-	}
-
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+	padding: 7px;
 }
 
-@media #{$large-down} {
 
-	li #woocommerce-cart-menu-item .widget_shopping_cart {
+@media #{$medium-down} {
+
+	.primer-wc-cart-menu .primer-wc-cart-sub-menu {
 		width: 100%;
 	}
 

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -1,4 +1,5 @@
 .main-navigation-container {
+	display: inline-block;
 	//background-color: $color__background-menu;
 
 	@media #{$large-down}{

--- a/.dev/sass/style.scss
+++ b/.dev/sass/style.scss
@@ -41,3 +41,4 @@
 @import "partials/genericons";
 @import "partials/social";
 @import "partials/jetpack";
+@import "compat/woocommerce";

--- a/functions.php
+++ b/functions.php
@@ -20,9 +20,11 @@ function lyrical_move_elements() {
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 	remove_action( 'primer_header', 'primer_add_site_title',               5 );
+	remove_action( 'primer_after_header', 'primer_generate_cart_submenu',  11 );
 
 	add_action( 'primer_header', 'primer_add_site_title',         5 );
 	add_action( 'primer_header', 'primer_add_primary_navigation', 5 );
+	add_action( 'primer_header', 'primer_generate_cart_submenu',  5 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/functions.php
+++ b/functions.php
@@ -21,8 +21,8 @@ function lyrical_move_elements() {
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 	remove_action( 'primer_header', 'primer_add_site_title',               5 );
 
-	add_action( 'primer_header', 'primer_add_site_title',         8 );
-	add_action( 'primer_header', 'primer_add_primary_navigation', 9 );
+	add_action( 'primer_header', 'primer_add_site_title',         5 );
+	add_action( 'primer_header', 'primer_add_primary_navigation', 5 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/functions.php
+++ b/functions.php
@@ -20,11 +20,9 @@ function lyrical_move_elements() {
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 	remove_action( 'primer_header', 'primer_add_site_title',               5 );
-	remove_action( 'primer_after_header', 'primer_generate_cart_submenu',  11 );
 
 	add_action( 'primer_header', 'primer_add_site_title',         5 );
 	add_action( 'primer_header', 'primer_add_primary_navigation', 5 );
-	add_action( 'primer_header', 'primer_generate_cart_submenu',  5 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
@@ -191,6 +189,11 @@ function lyrical_colors( $colors ) {
 		),
 		'button_color' => array(
 			'default'  => '#4c99ba',
+			'css'     => array(
+				'.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart p.buttons a' => array(
+					'background-color' => '%1$s',
+				),
+			),
 		),
 		'button_text_color' => array(
 			'default'  => '#ffffff',

--- a/functions.php
+++ b/functions.php
@@ -17,9 +17,9 @@ define( 'PRIMER_CHILD_VERSION', '1.0.0' );
  */
 function lyrical_move_elements() {
 
-	remove_action( 'primer_after_header', 'primer_add_primary_navigation' );
-	remove_action( 'primer_after_header', 'primer_add_page_title' );
-	remove_action( 'primer_header', 'primer_add_site_title' );
+	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
+	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
+	remove_action( 'primer_header', 'primer_add_site_title',               5 );
 
 	add_action( 'primer_header', 'primer_add_site_title', 8 );
 	add_action( 'primer_header', 'primer_add_primary_navigation', 9 );

--- a/functions.php
+++ b/functions.php
@@ -21,12 +21,12 @@ function lyrical_move_elements() {
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 	remove_action( 'primer_header', 'primer_add_site_title',               5 );
 
-	add_action( 'primer_header', 'primer_add_site_title', 8 );
+	add_action( 'primer_header', 'primer_add_site_title',         8 );
 	add_action( 'primer_header', 'primer_add_primary_navigation', 9 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
-		add_action( 'primer_hero', 'primer_add_page_title' );
+		add_action( 'primer_hero', 'primer_add_page_title', 12 );
 
 	}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3965,116 +3965,87 @@ body.home .hero {
 #wpstats {
   display: none; }
 
-.main-navigation .menu-item-object-cart:hover a {
-  background: transparent; }
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
+  width: 250px; }
 
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
-  float: left;
-  display: none;
-  position: relative;
-  z-index: 10001; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
+.primer-wc-cart-menu .widget_shopping_cart {
   float: right;
-  padding: 0 1rem;
-  margin-bottom: .5em; }
-  .widget_shopping_cart .quantity {
+  padding: 0;
+  margin-bottom: 0; }
+  .primer-wc-cart-menu .widget_shopping_cart .quantity {
     display: block;
     float: right;
     font-style: italic; }
-  .widget_shopping_cart ul.product_list_widget {
+  .primer-wc-cart-menu .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
     right: 0;
     max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
+    overflow-y: auto;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    background: inherit; }
+  .primer-wc-cart-menu .widget_shopping_cart p.buttons,
+  .primer-wc-cart-menu .widget_shopping_cart .total,
+  .primer-wc-cart-menu .widget_shopping_cart .product_list_widget {
     float: right;
     width: 100%; }
-  .widget_shopping_cart .total strong {
-    text-index: 0; }
-  .widget_shopping_cart p.buttons {
-    padding: .5em;
-    margin: 0; }
-
-.woocommerce-cart-menu-item .sub-menu {
-  background: transparent; }
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-  padding: 0;
-  margin: 0;
-  width: 100%;
-  padding-bottom: 5px;
-  border-bottom: none;
-  padding: .5em 1em;
-  text-indent: 0;
-  opacity: 1;
-  transition: opacity .25s ease-out;
-  -moz-transition: opacity .25s ease-out;
-  -webkit-transition: opacity .25s ease-out;
-  -o-transition: opacity .25s ease-out; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
-    width: 100%;
-    max-width: 55px; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
-    border-bottom: none; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: .5em 0em;
-    margin: 0;
-    width: 100%;
-    text-indent: 1.75rem; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
-    opacity: .85; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  display: inline-block;
-  right: 0 !important;
-  background: inherit; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart {
-  padding: 0;
-  margin-bottom: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+  .primer-wc-cart-menu .widget_shopping_cart .total {
     margin: 0 0 10px 0;
     padding-top: 10px;
     text-align: center; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
-    text-indent: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-    text-align: center;
-    width: 100%;
-    text-indent: 0;
-    background-color: #62d7db; }
-    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
-      margin-bottom: 5px; }
+    .primer-wc-cart-menu .widget_shopping_cart .total strong {
+      text-indent: 0; }
+  .primer-wc-cart-menu .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin: 0; }
+    .primer-wc-cart-menu .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0;
+      background-color: #62d7db; }
+      .primer-wc-cart-menu .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
+  .primer-wc-cart-menu .widget_shopping_cart .cart_list {
+    background: transparent;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+      padding: 0;
+      margin: 0;
+      width: 100%;
+      padding-bottom: 5px;
+      border-bottom: none;
+      padding: .5em 1em;
+      text-indent: 0;
+      opacity: 1;
+      -webkit-transition: opacity .25s ease-out;
+      transition: opacity .25s ease-out; }
+      .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
+        width: 100%;
+        max-width: 55px; }
+      .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+        border-bottom: none;
+        background: inherit; }
+        .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove {
+          float: right;
+          padding: 0;
+          margin: 18px 15px 0 0;
+          z-index: 1001;
+          line-height: .8; }
+          .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove:hover {
+            background: red !important; }
+      .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+        padding: .5em 0em;
+        margin: 0;
+        width: 100%;
+        text-indent: 1.75rem; }
+      .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
+        opacity: .85; }
 
-.woocommerce-cart-menu-item .cart-preview-count {
+.primer-wc-cart-menu .cart-preview-count {
   margin-right: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative;
-  float: right;
-  padding: 0;
-  margin-top: 18px;
-  text-indent: 0;
-  margin-left: 5px;
-  z-index: 1001;
-  line-height: .8;
-  text-indent: 0 !important; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
-    background: red !important; }
 
 body.post-type-archive,
 body.single-product {
@@ -4096,17 +4067,19 @@ body.single-product span.onsale {
   top: 0;
   right: 0; }
 
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-  border-bottom: none;
-  text-indent: 15px;
-  margin-right: 10px;
-  color: inherit;
-  background: inherit; }
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  margin-bottom: 0; }
 
-@media only screen and (min-width: 61.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-right: -6em; } }
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px; }
 
-@media only screen and (max-width: 61.063em) {
-  li #woocommerce-cart-menu-item .widget_shopping_cart {
+@media only screen and (max-width: 40.063em) {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu {
     width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1997,10 +1997,12 @@ a {
   a:hover, a:focus, a:active {
     color: #6edade; }
 
-@media only screen and (max-width: 61.063em) {
-  .main-navigation-container {
-    clear: both;
-    z-index: 9999; } }
+.main-navigation-container {
+  display: inline-block; }
+  @media only screen and (max-width: 61.063em) {
+    .main-navigation-container {
+      clear: both;
+      z-index: 9999; } }
 
 .main-navigation {
   display: none;
@@ -3962,3 +3964,100 @@ body.home .hero {
 
 #wpstats {
   display: none; }
+
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+  float: left; }
+
+.main-navigation .menu-item-object-cart a {
+  padding-right: 0;
+  float: left;
+  cursor: pointer; }
+
+.main-navigation .menu-item-object-cart a i {
+  font-size: 20px; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+  float: right;
+  margin-left: 1rem;
+  font-weight: bold; }
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+  float: right;
+  font-weight: 200; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: left;
+  display: none;
+  position: relative;
+  z-index: 10001;
+  background: #1985a1; }
+
+ul.site-header-cart.menu li {
+  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+  -webkit-box-shadow: 0 0 10px 0 grey;
+  box-shadow: 0 0 10px 0 grey; }
+
+ul.site-header-cart.menu ul.product_list_widget li {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+ul.site-header-cart.menu .widget_shopping_cart {
+  margin-bottom: 0;
+  padding: 10px 0 2px 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+  padding: 0 .5em;
+  max-height: 220px;
+  overflow-y: auto; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+  width: 55px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; }
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+  padding: 10px;
+  margin: .5em 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+  padding: 0 .5em;
+  margin: 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+  display: block;
+  width: 100%;
+  text-align: center; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
+  padding-top: 2px; }
+
+.site-header-cart-container {
+  width: 100%;
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin-top: 8px; }
+
+.site-header-cart-container .buttons a {
+  margin-bottom: 5px; }
+
+body.woocommerce .quantity input.input-text.qty {
+  padding: .45em; }
+
+@media only screen and (max-width: 61.063em) {
+  .menu-item-object-cart {
+    display: none; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3992,7 +3992,9 @@ ul.site-header-cart.menu {
     font-style: italic; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    right: 0; }
+    right: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {
@@ -4073,6 +4075,26 @@ ul.site-header-cart.menu {
   text-indent: 0 !important; }
   .woocommerce-cart-menu-item .cart_list li a.remove:hover {
     background: red !important; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  right: 0; }
 
 li#woocommerce-cart-menu-item li.mini_cart_item a {
   border-bottom: none;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4034,7 +4034,7 @@ body.home .hero {
         .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove {
           float: right;
           padding: 0;
-          margin: 18px 15px 0 0;
+          margin: 20px 15px 0 0;
           z-index: 1001;
           line-height: .8; }
           .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove:hover {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4082,6 +4082,11 @@ body.single-product span.onsale {
 .woocommerce-page table.cart td.actions .input-text {
   padding: 7px; }
 
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
+
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu {
     width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4072,7 +4072,9 @@ body.single-product span.onsale {
 .woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
-  margin-bottom: 0; }
+  max-width: 90px;
+  display: block;
+  margin: 0 auto; }
 
 .woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3977,7 +3977,7 @@ body.home .hero {
     float: right;
     font-style: italic; }
   .primer-wc-cart-menu .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
+    position: relative;
     right: 0;
     max-height: 250px;
     overflow-y: auto;
@@ -4035,7 +4035,7 @@ body.home .hero {
           z-index: 1001;
           line-height: .8; }
           .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove:hover {
-            background: red !important; }
+            background: red; }
       .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
         padding: .5em 0em;
         margin: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4067,6 +4067,9 @@ body.single-product span.onsale {
   top: 0;
   right: 0; }
 
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
 .woocommerce #content table.cart img,
 .woocommerce table.cart img,
 .woocommerce-page #content table.cart img,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4078,8 +4078,13 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
   border-bottom: none;
   text-indent: 15px;
   margin-right: 10px;
-  color: inherit; }
+  color: inherit;
+  background: inherit; }
 
-@media only screen and (min-width: 40.063em) {
+@media only screen and (min-width: 61.063em) {
   li#woocommerce-cart-menu-item .sub-menu {
     margin-right: -6em; } }
+
+@media only screen and (max-width: 61.063em) {
+  li #woocommerce-cart-menu-item .widget_shopping_cart {
+    width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3971,7 +3971,8 @@ body.home .hero {
 .primer-wc-cart-menu .widget_shopping_cart {
   float: right;
   padding: 0;
-  margin-bottom: 0; }
+  margin-bottom: 0;
+  background: #1985a1; }
   .primer-wc-cart-menu .widget_shopping_cart .quantity {
     display: block;
     float: right;
@@ -3992,13 +3993,15 @@ body.home .hero {
     float: right;
     width: 100%; }
   .primer-wc-cart-menu .widget_shopping_cart .total {
-    margin: 0 0 10px 0;
-    padding-top: 10px;
-    text-align: center; }
+    margin: 0;
+    padding: 10px 0;
+    text-align: center;
+    color: #333; }
     .primer-wc-cart-menu .widget_shopping_cart .total strong {
       text-indent: 0; }
   .primer-wc-cart-menu .widget_shopping_cart p.buttons {
     padding: .5em;
+    padding-top: 0;
     margin: 0; }
     .primer-wc-cart-menu .widget_shopping_cart p.buttons a {
       text-align: center;
@@ -4037,7 +4040,7 @@ body.home .hero {
           .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove:hover {
             background: red; }
       .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-        padding: .5em 0em;
+        padding: .5em 0 0 0;
         margin: 0;
         width: 100%;
         text-indent: 1.75rem; }
@@ -4070,26 +4073,22 @@ body.single-product span.onsale {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
-  max-width: 90px;
-  display: block;
-  margin: 0 auto; }
+  max-width: 100px;
+  margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 7px; }
+  padding: 10px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
   font-size: 16px;
   text-align: center; }
 
-@media only screen and (max-width: 40.063em) {
-  .primer-wc-cart-menu .primer-wc-cart-sub-menu {
+@media only screen and (max-width: 61.063em) {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu,
+  .primer-wc-cart-menu .widget_shopping_cart {
     width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3965,31 +3965,8 @@ body.home .hero {
 #wpstats {
   display: none; }
 
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-  float: left; }
-
-.main-navigation .menu-item-object-cart a {
-  padding-right: 0;
-  float: left;
-  cursor: pointer; }
-
-.main-navigation .menu-item-object-cart a i {
-  font-size: 20px; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-  float: right;
-  margin-left: 1rem;
-  font-weight: bold; }
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-  float: right;
-  font-weight: 200; }
 
 ul.site-header-cart.menu {
   width: 100%;
@@ -3999,65 +3976,110 @@ ul.site-header-cart.menu {
   float: left;
   display: none;
   position: relative;
-  z-index: 10001;
-  background: #1985a1; }
+  z-index: 10001; }
 
-ul.site-header-cart.menu li {
-  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-  -webkit-box-shadow: 0 0 10px 0 grey;
-  box-shadow: 0 0 10px 0 grey; }
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li {
+.widget_shopping_cart {
+  float: right;
+  padding: 0 1rem;
+  margin-bottom: .5em; }
+  .widget_shopping_cart .quantity {
+    display: block;
+    float: right;
+    font-style: italic; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    right: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: right;
+    width: 100%; }
+  .widget_shopping_cart .total strong {
+    text-index: 0; }
+  .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin: 0; }
+
+.woocommerce-cart-menu-item .sub-menu {
+  background: transparent; }
+
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: none;
+  padding: .5em 1em;
+  text-indent: 0;
+  opacity: 1;
+  transition: opacity .25s ease-out;
+  -moz-transition: opacity .25s ease-out;
+  -webkit-transition: opacity .25s ease-out;
+  -o-transition: opacity .25s ease-out; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
+    width: 100%;
+    max-width: 55px; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
+    border-bottom: none; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: .5em 0em;
+    margin: 0;
+    width: 100%;
+    text-indent: 1.75rem; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
+    opacity: .85; }
+
+.woocommerce-cart-menu-item .product_list_widget {
   border: none;
   -webkit-box-shadow: none;
-  box-shadow: none; }
+  box-shadow: none;
+  display: inline-block;
+  right: 0 !important;
+  background: inherit; }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-  margin-bottom: 0;
-  padding: 10px 0 2px 0; }
+.woocommerce-cart-menu-item .widget_shopping_cart {
+  padding: 0;
+  margin-bottom: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+    margin: 0 0 10px 0;
+    padding-top: 10px;
+    text-align: center; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
+    text-indent: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
+    text-align: center;
+    width: 100%;
+    text-indent: 0;
+    background-color: #62d7db; }
+    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
+      margin-bottom: 5px; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-  padding: 0 .5em;
-  max-height: 220px;
-  overflow-y: auto; }
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-right: 8px; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-  width: 55px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px; }
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative;
+  float: right;
+  padding: 0;
+  margin-top: 18px;
+  text-indent: 0;
+  margin-left: 5px;
+  z-index: 1001;
+  line-height: .8;
+  text-indent: 0 !important; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red !important; }
 
-ul.site-header-cart.menu .widget_shopping_cart .total {
-  padding: 10px;
-  margin: .5em 0; }
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+  border-bottom: none;
+  text-indent: 15px;
+  margin-right: 10px;
+  color: inherit; }
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-  padding: 0 .5em;
-  margin: 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-  display: block;
-  width: 100%;
-  text-align: center; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
-  padding-top: 2px; }
-
-.site-header-cart-container {
-  width: 100%;
-  display: block;
-  max-width: 1100px;
-  margin: 0 auto;
-  position: absolute;
-  left: 0;
-  right: 0;
-  margin-top: 8px; }
-
-.site-header-cart-container .buttons a {
-  margin-bottom: 5px; }
-
-body.woocommerce .quantity input.input-text.qty {
-  padding: .45em; }
-
-@media only screen and (max-width: 61.063em) {
-  .menu-item-object-cart {
-    display: none; } }
+@media only screen and (min-width: 40.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-right: -6em; } }

--- a/style.css
+++ b/style.css
@@ -3965,31 +3965,8 @@ body.home .hero {
 #wpstats {
   display: none; }
 
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-  float: right; }
-
-.main-navigation .menu-item-object-cart a {
-  padding-left: 0;
-  float: right;
-  cursor: pointer; }
-
-.main-navigation .menu-item-object-cart a i {
-  font-size: 20px; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-  float: left;
-  margin-right: 1rem;
-  font-weight: bold; }
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-  float: left;
-  font-weight: 200; }
 
 ul.site-header-cart.menu {
   width: 100%;
@@ -3999,65 +3976,110 @@ ul.site-header-cart.menu {
   float: right;
   display: none;
   position: relative;
-  z-index: 10001;
-  background: #1985a1; }
+  z-index: 10001; }
 
-ul.site-header-cart.menu li {
-  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-  -webkit-box-shadow: 0 0 10px 0 grey;
-  box-shadow: 0 0 10px 0 grey; }
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li {
+.widget_shopping_cart {
+  float: left;
+  padding: 0 1rem;
+  margin-bottom: .5em; }
+  .widget_shopping_cart .quantity {
+    display: block;
+    float: left;
+    font-style: italic; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    left: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: left;
+    width: 100%; }
+  .widget_shopping_cart .total strong {
+    text-index: 0; }
+  .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin: 0; }
+
+.woocommerce-cart-menu-item .sub-menu {
+  background: transparent; }
+
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: none;
+  padding: .5em 1em;
+  text-indent: 0;
+  opacity: 1;
+  transition: opacity .25s ease-out;
+  -moz-transition: opacity .25s ease-out;
+  -webkit-transition: opacity .25s ease-out;
+  -o-transition: opacity .25s ease-out; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
+    width: 100%;
+    max-width: 55px; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
+    border-bottom: none; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: .5em 0em;
+    margin: 0;
+    width: 100%;
+    text-indent: 1.75rem; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
+    opacity: .85; }
+
+.woocommerce-cart-menu-item .product_list_widget {
   border: none;
   -webkit-box-shadow: none;
-  box-shadow: none; }
+  box-shadow: none;
+  display: inline-block;
+  left: 0 !important;
+  background: inherit; }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-  margin-bottom: 0;
-  padding: 10px 0 2px 0; }
+.woocommerce-cart-menu-item .widget_shopping_cart {
+  padding: 0;
+  margin-bottom: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+    margin: 0 0 10px 0;
+    padding-top: 10px;
+    text-align: center; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
+    text-indent: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
+    text-align: center;
+    width: 100%;
+    text-indent: 0;
+    background-color: #62d7db; }
+    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
+      margin-bottom: 5px; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-  padding: 0 .5em;
-  max-height: 220px;
-  overflow-y: auto; }
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-left: 8px; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-  width: 55px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px; }
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative;
+  float: left;
+  padding: 0;
+  margin-top: 18px;
+  text-indent: 0;
+  margin-right: 5px;
+  z-index: 1001;
+  line-height: .8;
+  text-indent: 0 !important; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red !important; }
 
-ul.site-header-cart.menu .widget_shopping_cart .total {
-  padding: 10px;
-  margin: .5em 0; }
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+  border-bottom: none;
+  text-indent: 15px;
+  margin-left: 10px;
+  color: inherit; }
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-  padding: 0 .5em;
-  margin: 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-  display: block;
-  width: 100%;
-  text-align: center; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
-  padding-top: 2px; }
-
-.site-header-cart-container {
-  width: 100%;
-  display: block;
-  max-width: 1100px;
-  margin: 0 auto;
-  position: absolute;
-  right: 0;
-  left: 0;
-  margin-top: 8px; }
-
-.site-header-cart-container .buttons a {
-  margin-bottom: 5px; }
-
-body.woocommerce .quantity input.input-text.qty {
-  padding: .45em; }
-
-@media only screen and (max-width: 61.063em) {
-  .menu-item-object-cart {
-    display: none; } }
+@media only screen and (min-width: 40.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-left: -6em; } }

--- a/style.css
+++ b/style.css
@@ -4082,6 +4082,11 @@ body.single-product span.onsale {
 .woocommerce-page table.cart td.actions .input-text {
   padding: 7px; }
 
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
+
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu {
     width: 100%; } }

--- a/style.css
+++ b/style.css
@@ -4034,7 +4034,7 @@ body.home .hero {
         .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove {
           float: left;
           padding: 0;
-          margin: 18px 0 0 15px;
+          margin: 20px 0 0 15px;
           z-index: 1001;
           line-height: .8; }
           .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove:hover {

--- a/style.css
+++ b/style.css
@@ -3977,7 +3977,7 @@ body.home .hero {
     float: left;
     font-style: italic; }
   .primer-wc-cart-menu .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
+    position: relative;
     left: 0;
     max-height: 250px;
     overflow-y: auto;
@@ -4035,7 +4035,7 @@ body.home .hero {
           z-index: 1001;
           line-height: .8; }
           .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove:hover {
-            background: red !important; }
+            background: red; }
       .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
         padding: .5em 0em;
         margin: 0;

--- a/style.css
+++ b/style.css
@@ -4072,7 +4072,9 @@ body.single-product span.onsale {
 .woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
-  margin-bottom: 0; }
+  max-width: 90px;
+  display: block;
+  margin: 0 auto; }
 
 .woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,

--- a/style.css
+++ b/style.css
@@ -4067,6 +4067,9 @@ body.single-product span.onsale {
   top: 0;
   left: 0; }
 
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
 .woocommerce #content table.cart img,
 .woocommerce table.cart img,
 .woocommerce-page #content table.cart img,

--- a/style.css
+++ b/style.css
@@ -3965,116 +3965,87 @@ body.home .hero {
 #wpstats {
   display: none; }
 
-.main-navigation .menu-item-object-cart:hover a {
-  background: transparent; }
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
+  width: 250px; }
 
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
-  float: right;
-  display: none;
-  position: relative;
-  z-index: 10001; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
+.primer-wc-cart-menu .widget_shopping_cart {
   float: left;
-  padding: 0 1rem;
-  margin-bottom: .5em; }
-  .widget_shopping_cart .quantity {
+  padding: 0;
+  margin-bottom: 0; }
+  .primer-wc-cart-menu .widget_shopping_cart .quantity {
     display: block;
     float: left;
     font-style: italic; }
-  .widget_shopping_cart ul.product_list_widget {
+  .primer-wc-cart-menu .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
     left: 0;
     max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
+    overflow-y: auto;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    background: inherit; }
+  .primer-wc-cart-menu .widget_shopping_cart p.buttons,
+  .primer-wc-cart-menu .widget_shopping_cart .total,
+  .primer-wc-cart-menu .widget_shopping_cart .product_list_widget {
     float: left;
     width: 100%; }
-  .widget_shopping_cart .total strong {
-    text-index: 0; }
-  .widget_shopping_cart p.buttons {
-    padding: .5em;
-    margin: 0; }
-
-.woocommerce-cart-menu-item .sub-menu {
-  background: transparent; }
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-  padding: 0;
-  margin: 0;
-  width: 100%;
-  padding-bottom: 5px;
-  border-bottom: none;
-  padding: .5em 1em;
-  text-indent: 0;
-  opacity: 1;
-  transition: opacity .25s ease-out;
-  -moz-transition: opacity .25s ease-out;
-  -webkit-transition: opacity .25s ease-out;
-  -o-transition: opacity .25s ease-out; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
-    width: 100%;
-    max-width: 55px; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
-    border-bottom: none; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: .5em 0em;
-    margin: 0;
-    width: 100%;
-    text-indent: 1.75rem; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
-    opacity: .85; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  display: inline-block;
-  left: 0 !important;
-  background: inherit; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart {
-  padding: 0;
-  margin-bottom: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+  .primer-wc-cart-menu .widget_shopping_cart .total {
     margin: 0 0 10px 0;
     padding-top: 10px;
     text-align: center; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
-    text-indent: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-    text-align: center;
-    width: 100%;
-    text-indent: 0;
-    background-color: #62d7db; }
-    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
-      margin-bottom: 5px; }
+    .primer-wc-cart-menu .widget_shopping_cart .total strong {
+      text-indent: 0; }
+  .primer-wc-cart-menu .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin: 0; }
+    .primer-wc-cart-menu .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0;
+      background-color: #62d7db; }
+      .primer-wc-cart-menu .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
+  .primer-wc-cart-menu .widget_shopping_cart .cart_list {
+    background: transparent;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+    .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+      padding: 0;
+      margin: 0;
+      width: 100%;
+      padding-bottom: 5px;
+      border-bottom: none;
+      padding: .5em 1em;
+      text-indent: 0;
+      opacity: 1;
+      -webkit-transition: opacity .25s ease-out;
+      transition: opacity .25s ease-out; }
+      .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
+        width: 100%;
+        max-width: 55px; }
+      .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+        border-bottom: none;
+        background: inherit; }
+        .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove {
+          float: left;
+          padding: 0;
+          margin: 18px 0 0 15px;
+          z-index: 1001;
+          line-height: .8; }
+          .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove:hover {
+            background: red !important; }
+      .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+        padding: .5em 0em;
+        margin: 0;
+        width: 100%;
+        text-indent: 1.75rem; }
+      .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
+        opacity: .85; }
 
-.woocommerce-cart-menu-item .cart-preview-count {
+.primer-wc-cart-menu .cart-preview-count {
   margin-left: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative;
-  float: left;
-  padding: 0;
-  margin-top: 18px;
-  text-indent: 0;
-  margin-right: 5px;
-  z-index: 1001;
-  line-height: .8;
-  text-indent: 0 !important; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
-    background: red !important; }
 
 body.post-type-archive,
 body.single-product {
@@ -4096,17 +4067,19 @@ body.single-product span.onsale {
   top: 0;
   left: 0; }
 
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-  border-bottom: none;
-  text-indent: 15px;
-  margin-left: 10px;
-  color: inherit;
-  background: inherit; }
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  margin-bottom: 0; }
 
-@media only screen and (min-width: 61.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-left: -6em; } }
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 7px; }
 
-@media only screen and (max-width: 61.063em) {
-  li #woocommerce-cart-menu-item .widget_shopping_cart {
+@media only screen and (max-width: 40.063em) {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu {
     width: 100%; } }

--- a/style.css
+++ b/style.css
@@ -3992,7 +3992,9 @@ ul.site-header-cart.menu {
     font-style: italic; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    left: 0; }
+    left: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {
@@ -4073,6 +4075,26 @@ ul.site-header-cart.menu {
   text-indent: 0 !important; }
   .woocommerce-cart-menu-item .cart_list li a.remove:hover {
     background: red !important; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  left: 0; }
 
 li#woocommerce-cart-menu-item li.mini_cart_item a {
   border-bottom: none;

--- a/style.css
+++ b/style.css
@@ -3971,7 +3971,8 @@ body.home .hero {
 .primer-wc-cart-menu .widget_shopping_cart {
   float: left;
   padding: 0;
-  margin-bottom: 0; }
+  margin-bottom: 0;
+  background: #1985a1; }
   .primer-wc-cart-menu .widget_shopping_cart .quantity {
     display: block;
     float: left;
@@ -3992,13 +3993,15 @@ body.home .hero {
     float: left;
     width: 100%; }
   .primer-wc-cart-menu .widget_shopping_cart .total {
-    margin: 0 0 10px 0;
-    padding-top: 10px;
-    text-align: center; }
+    margin: 0;
+    padding: 10px 0;
+    text-align: center;
+    color: #333; }
     .primer-wc-cart-menu .widget_shopping_cart .total strong {
       text-indent: 0; }
   .primer-wc-cart-menu .widget_shopping_cart p.buttons {
     padding: .5em;
+    padding-top: 0;
     margin: 0; }
     .primer-wc-cart-menu .widget_shopping_cart p.buttons a {
       text-align: center;
@@ -4037,7 +4040,7 @@ body.home .hero {
           .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a.remove:hover {
             background: red; }
       .primer-wc-cart-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-        padding: .5em 0em;
+        padding: .5em 0 0 0;
         margin: 0;
         width: 100%;
         text-indent: 1.75rem; }
@@ -4070,26 +4073,22 @@ body.single-product span.onsale {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
-  max-width: 90px;
-  display: block;
-  margin: 0 auto; }
+  max-width: 100px;
+  margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 7px; }
+  padding: 10px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
   font-size: 16px;
   text-align: center; }
 
-@media only screen and (max-width: 40.063em) {
-  .primer-wc-cart-menu .primer-wc-cart-sub-menu {
+@media only screen and (max-width: 61.063em) {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu,
+  .primer-wc-cart-menu .widget_shopping_cart {
     width: 100%; } }

--- a/style.css
+++ b/style.css
@@ -1997,10 +1997,12 @@ a {
   a:hover, a:focus, a:active {
     color: #6edade; }
 
-@media only screen and (max-width: 61.063em) {
-  .main-navigation-container {
-    clear: both;
-    z-index: 9999; } }
+.main-navigation-container {
+  display: inline-block; }
+  @media only screen and (max-width: 61.063em) {
+    .main-navigation-container {
+      clear: both;
+      z-index: 9999; } }
 
 .main-navigation {
   display: none;
@@ -3962,3 +3964,100 @@ body.home .hero {
 
 #wpstats {
   display: none; }
+
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+  float: right; }
+
+.main-navigation .menu-item-object-cart a {
+  padding-left: 0;
+  float: right;
+  cursor: pointer; }
+
+.main-navigation .menu-item-object-cart a i {
+  font-size: 20px; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+  float: left;
+  margin-right: 1rem;
+  font-weight: bold; }
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+  float: left;
+  font-weight: 200; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: right;
+  display: none;
+  position: relative;
+  z-index: 10001;
+  background: #1985a1; }
+
+ul.site-header-cart.menu li {
+  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+  -webkit-box-shadow: 0 0 10px 0 grey;
+  box-shadow: 0 0 10px 0 grey; }
+
+ul.site-header-cart.menu ul.product_list_widget li {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+ul.site-header-cart.menu .widget_shopping_cart {
+  margin-bottom: 0;
+  padding: 10px 0 2px 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+  padding: 0 .5em;
+  max-height: 220px;
+  overflow-y: auto; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+  width: 55px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; }
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+  padding: 10px;
+  margin: .5em 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+  padding: 0 .5em;
+  margin: 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+  display: block;
+  width: 100%;
+  text-align: center; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
+  padding-top: 2px; }
+
+.site-header-cart-container {
+  width: 100%;
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+  position: absolute;
+  right: 0;
+  left: 0;
+  margin-top: 8px; }
+
+.site-header-cart-container .buttons a {
+  margin-bottom: 5px; }
+
+body.woocommerce .quantity input.input-text.qty {
+  padding: .45em; }
+
+@media only screen and (max-width: 61.063em) {
+  .menu-item-object-cart {
+    display: none; } }

--- a/style.css
+++ b/style.css
@@ -4078,8 +4078,13 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
   border-bottom: none;
   text-indent: 15px;
   margin-left: 10px;
-  color: inherit; }
+  color: inherit;
+  background: inherit; }
 
-@media only screen and (min-width: 40.063em) {
+@media only screen and (min-width: 61.063em) {
   li#woocommerce-cart-menu-item .sub-menu {
     margin-left: -6em; } }
+
+@media only screen and (max-width: 61.063em) {
+  li #woocommerce-cart-menu-item .widget_shopping_cart {
+    width: 100%; } }


### PR DESCRIPTION
The new version of primer add's priorities to some functions to allow for more precise injection of content or easier management of the content flow.

This patch add's the required priorities to ensure compatibility with the latest version of primer.

**Requires:** https://github.com/godaddy/wp-primer-theme/pull/146