### PR TITLE
Prevent i10n WooCommerce button overlap/overflow, tweak font size, remove on sale comment

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -123,9 +123,21 @@
 	}
 }
 
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+	max-width: 100%;
+	white-space: normal;
+	text-align: center;
+	display: block;
+
+	@media #{$large-up} {
+		font-size: 0.75rem;
+	}
+
+}
+
 body.post-type-archive,
 body.single-product {
-	/* On Sale Badge */
 	span.onsale,
 	ul.products li.product .onsale {
 		padding: 2px 8px;

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -136,6 +136,10 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
 
 }
 
+.woocommerce a.added_to_cart {
+	text-align: left;
+}
+
 body.post-type-archive,
 body.single-product {
 	span.onsale,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4064,20 +4064,28 @@ body.home .hero {
   .primer-wc-cart-menu .cart-preview-count {
     margin-right: 8px; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 61.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4075,6 +4075,9 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
     .woocommerce a.added_to_cart {
       font-size: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: right; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style.css
+++ b/style.css
@@ -4075,6 +4075,9 @@ body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
     .woocommerce a.added_to_cart {
       font-size: 0.75rem; } }
 
+.woocommerce a.added_to_cart {
+  text-align: left; }
+
 body.post-type-archive span.onsale,
 body.post-type-archive ul.products li.product .onsale,
 body.single-product span.onsale,

--- a/style.css
+++ b/style.css
@@ -4064,20 +4064,28 @@ body.home .hero {
   .primer-wc-cart-menu .cart-preview-count {
     margin-left: 8px; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 61.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;


### PR DESCRIPTION
@fjarrett Please review.

Prevent button overlaps, adjust font size for WooCommerce compat.

Related https://github.com/godaddy/wp-primer-theme/pull/167

![example](https://cldup.com/xLw6x7BZCv.png)