### PR TITLE
WooCommerce style tweaks

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -123,6 +123,75 @@
 	}
 }
 
+.woocommerce-page {
+
+	div.product {
+
+		.woocommerce-product-gallery {
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+		}
+
+		.summary {
+			margin-top: 0;
+		}
+
+		.commentlist {
+			padding-left: 0;
+		}
+
+	}
+
+	&.woocommerce div.product form.cart {
+		margin: 1em 0;
+	}
+
+	ul.products li.product.primer-2-column-product {
+		width: 48.05%;
+	}
+
+	.primer-woocommerce .cart .qty {
+		padding: 0.5em;
+	}
+
+	#reviews #comments ol.commentlist li {
+
+		img.avatar {
+			width: 60px;
+		}
+
+		.comment-text {
+			margin: 0 0 0 80px;
+		}
+
+	}
+
+	form.woocommerce-cart-form {
+
+		table.cart td.actions #coupon_code {
+			width: 55%;
+			margin-right: 0;
+		}
+
+	}
+
+	table.cart {
+		img {
+			width: 100%;
+			max-width: 100px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 10px !important;
+		}
+	}
+
+}
+
 body.post-type-archive,
 body.single-product {
 	/* On Sale Badge */
@@ -148,21 +217,6 @@ body.single-product {
 body.woocommerce-cart {
 	.primer-wc-cart-sub-menu {
 		display: none;
-	}
-}
-
-.woocommerce,
-.woocommerce-page {
-	table.cart {
-		img {
-			width: 100%;
-			max-width: 100px;
-			margin-bottom: 0;
-		}
-
-		td.actions .input-text {
-			padding: 10px !important;
-		}
 	}
 }
 

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -178,6 +178,10 @@
 
 	}
 
+	table.variations tr:hover td {
+		background-color: transparent;
+	}
+
 	table.cart {
 		img {
 			width: 100%;

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -157,6 +157,16 @@
 		padding: 0.5em;
 	}
 
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
 	#reviews #comments ol.commentlist li {
 
 		img.avatar {
@@ -194,20 +204,6 @@
 		}
 	}
 
-}
-
-body.post-type-archive,
-body.single-product {
-	/* On Sale Badge */
-	span.onsale,
-	ul.products li.product .onsale {
-		padding: 2px 8px;
-		border-radius: 0;
-		margin: 0;
-		min-height: auto;
-		min-width: auto;
-		line-height: inherit;
-	}
 }
 
 body.single-product {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -224,6 +224,7 @@ body.woocommerce-cart {
 	width: 100%;
 	font-size: 16px;
 	text-align: center;
+	white-space: normal;
 }
 
 @media #{$large-down} {

--- a/.dev/sass/partials/_menus.scss
+++ b/.dev/sass/partials/_menus.scss
@@ -1,6 +1,5 @@
 .main-navigation-container {
-	display: inline-block;
-	//background-color: $color__background-menu;
+	display: block;
 
 	@media #{$large-down}{
 		clear: both;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4064,6 +4064,42 @@ body.home .hero {
   .primer-wc-cart-menu .cart-preview-count {
     margin-right: 8px; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-right: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.5em; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 80px 0 0; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 55%;
+  margin-left: 0; }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 10px !important; }
+
 body.post-type-archive,
 body.single-product {
   /* On Sale Badge */ }
@@ -4086,16 +4122,6 @@ body.single-product span.onsale {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 10px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4082,6 +4082,16 @@ body.home .hero {
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.5em; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page #reviews #comments ol.commentlist li img.avatar {
   width: 60px; }
 
@@ -4102,21 +4112,6 @@ body.home .hero {
 
 .woocommerce-page table.cart td.actions .input-text {
   padding: 10px !important; }
-
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2010,7 +2010,7 @@ a {
     color: #6edade; }
 
 .main-navigation-container {
-  display: inline-block; }
+  display: block; }
   @media only screen and (max-width: 61.063em) {
     .main-navigation-container {
       clear: both;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4124,7 +4124,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
   font-size: 16px;
-  text-align: center; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 61.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4092,6 +4092,9 @@ body.home .hero {
   width: 55%;
   margin-left: 0; }
 
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;

--- a/style.css
+++ b/style.css
@@ -4082,6 +4082,16 @@ body.home .hero {
 .woocommerce-page .primer-woocommerce .cart .qty {
   padding: 0.5em; }
 
+.woocommerce-page span.onsale,
+.woocommerce-page ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
+
 .woocommerce-page #reviews #comments ol.commentlist li img.avatar {
   width: 60px; }
 
@@ -4102,21 +4112,6 @@ body.home .hero {
 
 .woocommerce-page table.cart td.actions .input-text {
   padding: 10px !important; }
-
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -4064,6 +4064,42 @@ body.home .hero {
   .primer-wc-cart-menu .cart-preview-count {
     margin-left: 8px; }
 
+.woocommerce-page div.product .woocommerce-product-gallery figure.woocommerce-product-gallery__wrapper {
+  margin: 0; }
+
+.woocommerce-page div.product .summary {
+  margin-top: 0; }
+
+.woocommerce-page div.product .commentlist {
+  padding-left: 0; }
+
+.woocommerce-page.woocommerce div.product form.cart {
+  margin: 1em 0; }
+
+.woocommerce-page ul.products li.product.primer-2-column-product {
+  width: 48.05%; }
+
+.woocommerce-page .primer-woocommerce .cart .qty {
+  padding: 0.5em; }
+
+.woocommerce-page #reviews #comments ol.commentlist li img.avatar {
+  width: 60px; }
+
+.woocommerce-page #reviews #comments ol.commentlist li .comment-text {
+  margin: 0 0 0 80px; }
+
+.woocommerce-page form.woocommerce-cart-form table.cart td.actions #coupon_code {
+  width: 55%;
+  margin-right: 0; }
+
+.woocommerce-page table.cart img {
+  width: 100%;
+  max-width: 100px;
+  margin-bottom: 0; }
+
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 10px !important; }
+
 body.post-type-archive,
 body.single-product {
   /* On Sale Badge */ }
@@ -4086,16 +4122,6 @@ body.single-product span.onsale {
 
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
-
-.woocommerce table.cart img,
-.woocommerce-page table.cart img {
-  width: 100%;
-  max-width: 100px;
-  margin-bottom: 0; }
-
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-  padding: 10px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -2010,7 +2010,7 @@ a {
     color: #6edade; }
 
 .main-navigation-container {
-  display: inline-block; }
+  display: block; }
   @media only screen and (max-width: 61.063em) {
     .main-navigation-container {
       clear: both;

--- a/style.css
+++ b/style.css
@@ -4124,7 +4124,8 @@ body.woocommerce-cart .primer-wc-cart-sub-menu {
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;
   font-size: 16px;
-  text-align: center; }
+  text-align: center;
+  white-space: normal; }
 
 @media only screen and (max-width: 61.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu,

--- a/style.css
+++ b/style.css
@@ -4092,6 +4092,9 @@ body.home .hero {
   width: 55%;
   margin-right: 0; }
 
+.woocommerce-page table.variations tr:hover td {
+  background-color: transparent; }
+
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;


### PR DESCRIPTION
WooCommerce related patch. Updates to WooCommerce compatibility styles.

For related changes see https://github.com/godaddy/wp-primer-theme/pull/182

*Before merge:*
This PR needs to be updated to fix the text overflow for the 'Select Options' button on the WooCommerce variable products when the layout is set to 4 columns.

![Example](https://cldup.com/BMeO1r2Z_C.png)


*Fix*
The fix for overflowing button text is to set the white-space to normal. However, this now causes the add to cart button to break to two lines.

![Example](https://cldup.com/DP_ts-OAB4.png)

To prevent the buttons from breaking a few solutions exist:

1) Adjust the font size of the add to cart buttons, eg: 
```css
a.add_to_cart_button {
   font-size: 14px;
}
```

2) Set the `letter-spacing` to `normal` on the add to cart buttons. eg:
```css
a.add_to_cart_button {
   letter-spacing: normal;
}
```

3) Set the number of WooCommerce shop columns to < 3.

```php
add_filter( 'loop_shop_columns', 'loop_columns' );
if ( ! function_exists( 'loop_columns' ) ) {
	function loop_columns() {
		return 3; // 3 products per row
	}
}
```
<small>Source: https://docs.woocommerce.com/document/change-number-of-products-per-row/</small>